### PR TITLE
Remove redundant imports

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,6 +1,4 @@
 from SublimeLinter.lint import Linter, STREAM_STDERR
-import sublime
-import os
 
 
 class SublimeLinterZigCheck(Linter):


### PR DESCRIPTION
After simplifying the code the additional imports seem redundant. 